### PR TITLE
feat: remove AppShell

### DIFF
--- a/imports/ui/Layout.tsx
+++ b/imports/ui/Layout.tsx
@@ -1,5 +1,12 @@
-import React, { FC, ReactNode } from "react";
-import { AppShell, Flex, Center, Title, Button } from "@mantine/core";
+import React, { FC, Fragment, ReactNode } from "react";
+import {
+  AppShell,
+  Flex,
+  Center,
+  Title,
+  Button,
+  Container,
+} from "@mantine/core";
 import { useTracker } from "meteor/react-meteor-data";
 import { Meteor } from "meteor/meteor";
 import { useNavigate } from "react-router-dom";
@@ -15,33 +22,26 @@ export const Layout: FC<LayoutProps> = ({ children }) => {
     Meteor.logout(() => navigate("/login"));
   };
   return (
-    <AppShell header={{ height: 60 }} padding="md">
-      <AppShell.Header>
-        <Flex
-          className="bg-blue-500 h-full w-full"
-          align="center"
-          justify="space-between"
-        >
-          <Center className="ml-4 min-w-1/6 w-max">
-            <Title className="ml-1" order={3} c="white">
-              Meteor Todo
-            </Title>
-          </Center>
-          {userId ? (
-            <Center className="mr-4 min-w-1/6 w-max">
-              <Button color="red" onClick={handleLogout}>
-                Logout
-              </Button>
-            </Center>
-          ) : null}
+    <>
+      <Flex
+        align="center"
+        justify="space-between"
+        className="fixed w-screen overflow-auto top-0 bg-blue-500 shadow-md z-10 h-[80px]"
+      >
+        <Flex ml={16} justify="between" align="center" py={2}>
+          <Title order={3} className="text-white text-lg font-semibold">
+            Meteor Todo
+          </Title>
         </Flex>
-      </AppShell.Header>
 
-      <AppShell.Main>
-        <AppShell.Section>
-          <Center>{children}</Center>
-        </AppShell.Section>
-      </AppShell.Main>
-    </AppShell>
+        <Button color="red" mr={16} onClick={handleLogout}>
+          Logout
+        </Button>
+      </Flex>
+
+      <Center mt={150} mb={20}>
+        {children}
+      </Center>
+    </>
   );
 };


### PR DESCRIPTION
Due to a bug happening on the deployed version of the app I decided to remove the `AppShell` component from mantine and use other mantine components alongside with tailwind in the `Layout.tsx` component
![image](https://github.com/xsadia/meteor-todo/assets/62262571/83225637-50e5-457a-a22f-4ef18b09bad7)
